### PR TITLE
Added support for lib directory into deb packaging

### DIFF
--- a/slave-new/Makefile
+++ b/slave-new/Makefile
@@ -28,7 +28,7 @@ meta:
 
 $(processes):
 	@echo "Generating deb package for $@..."
-	@cd $@ && CONF=$@ envsubst < ../templates/Makefile > Makefile
+	@cd $@ && NAME=$@ envsubst < ../templates/Makefile > Makefile
 	@cd $@ && if [ -d conf ]; then cat ../templates/makefile_conf_part >> Makefile; fi
 	@cd $@ && if [ -d lib ]; then cat ../templates/makefile_lib_part >> Makefile; fi
 	cd $@ && DEBEMAIL=$(maintainer_email) DEBFULLNAME=$(maintainer_name) dh_make -s -i -y -n -p "$(package_prefix_name)$@_`cat version`" -t "$(realpath templates/dh_make)" --createorig

--- a/slave-new/Makefile
+++ b/slave-new/Makefile
@@ -30,6 +30,7 @@ $(processes):
 	@echo "Generating deb package for $@..."
 	@cd $@ && CONF=$@ envsubst < ../templates/Makefile > Makefile
 	@cd $@ && if [ -d conf ]; then cat ../templates/makefile_conf_part >> Makefile; fi
+	@cd $@ && if [ -d lib ]; then cat ../templates/makefile_lib_part >> Makefile; fi
 	cd $@ && DEBEMAIL=$(maintainer_email) DEBFULLNAME=$(maintainer_name) dh_make -s -i -y -n -p "$(package_prefix_name)$@_`cat version`" -t "$(realpath templates/dh_make)" --createorig
 	@cd $@/debian && rm *.ex *.EX README.*
 	@cd $@ && if [ -s changelog ]; then cp changelog ./debian/; fi

--- a/slave-new/templates/Makefile
+++ b/slave-new/templates/Makefile
@@ -3,6 +3,7 @@
 INSTALL = install
 CONFDIR = $(DESTDIR)/etc/perun/${CONF}.d
 BINDIR = $(DESTDIR)/opt/perun/bin
+LIBDIR = $(DESTDIR)/opt/perun/lib
 
 build: ;
 

--- a/slave-new/templates/Makefile
+++ b/slave-new/templates/Makefile
@@ -1,9 +1,9 @@
 #!/usr/bin/make -f
 
 INSTALL = install
-CONFDIR = $(DESTDIR)/etc/perun/${CONF}.d
+CONFDIR = $(DESTDIR)/etc/perun/${NAME}.d
 BINDIR = $(DESTDIR)/opt/perun/bin
-LIBDIR = $(DESTDIR)/opt/perun/lib
+LIBDIR = $(DESTDIR)/opt/perun/lib/${NAME}
 
 build: ;
 

--- a/slave-new/templates/makefile_lib_part
+++ b/slave-new/templates/makefile_lib_part
@@ -1,0 +1,2 @@
+	$(INSTALL) -d -m 755 $(LIBDIR)
+	$(INSTALL) ./lib/* $(LIBDIR)


### PR DESCRIPTION
Be aware that for example packages **process-ldap** and **process-ldap-vsb-vi** can't be installed on the same machine, because they both have the same content of their lib directories. Is this the desired behaviour? Don't you rather want the same directory structure as configuration files have (separate directory for every package)?
